### PR TITLE
`coset_extended_lagrange_to_coeffs` should return `Basis.MONOMIAL`

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -160,7 +160,7 @@ class Polynomial:
         inv_offset = 1 / offset
         return Polynomial(
             [v * inv_offset**i for (i, v) in enumerate(shifted_coeffs)],
-            Basis.LAGRANGE,
+            Basis.MONOMIAL,
         )
 
     # Given a polynomial expressed as a list of evaluations at roots of unity,


### PR DESCRIPTION
Closes #3 