### PR TITLE
Fix: evaluation at roots_of_unity always return 0

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -183,6 +183,9 @@ class Polynomial:
 
         order = len(self.values)
         roots_of_unity = Scalar.roots_of_unity(order)
+        elem = x.n % Scalar.field_modulus
+        if elem in roots_of_unity:
+            return self.values[roots_of_unity.index(elem)]
         return (
             (Scalar(x) ** order - 1)
             / order


### PR DESCRIPTION
Currently the evaluation at roots_of_unity always return 0, the code does not handle the logic, should return related value from self.values based on its index