### PR TITLE
docs: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The parts of PlonK that are responsible for ensuring strong privacy are left out
 3. Add support for lookups.
 A lookup argument allows us to prove that a certain element can be found in a public lookup table. [PlonKup](https://eprint.iacr.org/2022/086.pdf) introduces lookup arguments to PlonK. Try to understand the construction in the paper and implement it here.
 4. Implement Merlin transcript.
-Currently, this implementation uses the [merlin transcript package](https://github.com/nalinbhardwaj/curdleproofs.pie/tree/master/merlin). Learn about the [Merlin transcript construction](https://merlin.cool) and the [STROBE framework](https://www.cryptologie.net/article/416/the-strobe-protocol-framework/) which Merlin is based upon, and then implement the transcript class `MerlinTranscript` yourself!
+Currently, this implementation uses the [merlin transcript package](https://github.com/nalinbhardwaj/curdleproofs.pie/tree/master/merlin_transcripts). Learn about the [Merlin transcript construction](https://merlin.cool) and the [STROBE framework](https://www.cryptologie.net/article/416/the-strobe-protocol-framework/) which Merlin is based upon, and then implement the transcript class `MerlinTranscript` yourself!
 
 ## Getting started
 


### PR DESCRIPTION
Description: link to merlin_transcripts package is broken, now fixed in doc
No test needed